### PR TITLE
Add Linear and Rational-Quadratic Splines

### DIFF
--- a/FrEIA/modules/__init__.py
+++ b/FrEIA/modules/__init__.py
@@ -66,6 +66,7 @@ from .orthogonal import *
 from .inv_auto_layers import *
 from .invertible_resnet import *
 from .gaussian_mixture import *
+from .splines import *
 
 __all__ = [
             'InvertibleModule',
@@ -103,4 +104,6 @@ __all__ = [
             'Flatten',
             'Reshape',
             'GaussianMixtureModel',
+            'LinearSpline',
+            'RationalQuadraticSpline',
             ]

--- a/FrEIA/modules/splines/__init__.py
+++ b/FrEIA/modules/splines/__init__.py
@@ -1,0 +1,4 @@
+
+from .binned import *
+from .linear import *
+from .rational_quadratic import *

--- a/FrEIA/modules/splines/binned.py
+++ b/FrEIA/modules/splines/binned.py
@@ -1,0 +1,250 @@
+from typing import List, Tuple, Union
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from itertools import chain
+
+from FrEIA.modules.coupling_layers import _BaseCouplingBlock
+from FrEIA import utils
+
+
+class BinnedSpline(_BaseCouplingBlock):
+    """
+    Base Class for Splines
+    Implements input-binning, where bin knots are jointly predicted along with spline parameters
+    by a non-invertible coupling subnetwork
+    """
+    def __init__(self, dims_in, dims_c=None, subnet_constructor: callable = None, split_len: Union[float, int] = 0.5,
+                 bins: int = 10, parameter_counts: List[int] = None):
+        if dims_c is None:
+            dims_c = []
+        if parameter_counts is None:
+            parameter_counts = [1, bins, bins]
+
+        super().__init__(dims_in, dims_c, clamp=0.0, clamp_activation=lambda u: u, split_len=split_len)
+
+        num_params = sum(parameter_counts)
+        self.subnet1 = subnet_constructor(self.split_len2 + self.condition_length, self.split_len1 * num_params)
+        self.subnet2 = subnet_constructor(self.split_len1 + self.condition_length, self.split_len2 * num_params)
+
+        self.bins = bins
+        self.parameter_counts = parameter_counts
+
+    def spline1(self, x: torch.Tensor, left: torch.Tensor, right: torch.Tensor, bottom: torch.Tensor, top: torch.Tensor,
+                parameters: List[torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Perform the actual spline. Callees need to implement this method.
+        Args:
+            x: Inputs within the spline domain
+            left: Bin edge to the left of each input
+            right: Bin edge to the right of each input
+            bottom: Bin edge below each input
+            top: Bin edge above each input
+            parameters: Additional spline parameters
+            rev: whether to run in reverse
+
+        Returns:
+            splined output tensor
+            log jacobian matrix entries for splined inputs
+        """
+        raise NotImplementedError
+
+    def spline2(self, x: torch.Tensor, left: torch.Tensor, right: torch.Tensor, bottom: torch.Tensor, top: torch.Tensor,
+                parameters: List[torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+
+    def split_parameters(self, parameters: torch.Tensor, split_len: int) -> List[torch.Tensor]:
+        """
+        Split network output into semantic parameters, as given by self.parameter_counts
+        """
+        parameters = parameters.movedim(1, -1)
+        parameters = parameters.reshape(*parameters.shape[:-1], split_len, -1)
+        return list(torch.split(parameters, self.parameter_counts, dim=-1))
+
+    def constrain_parameters(self, parameters: List[torch.Tensor]) -> List[torch.Tensor]:
+        """
+        Constrain Parameters to meet certain conditions (e.g. positivity)
+        """
+        domain_width, bin_widths, bin_heights, *parameters = parameters
+
+        # constrain the domain width to positive values
+        # use a shifted softplus
+        shift = np.log(np.e - 1)
+        domain_width = F.softplus(domain_width + shift)
+
+        # bin widths must be positive and sum to 1
+        bin_widths = F.softmax(bin_widths, dim=-1)
+
+        # same for the bin heights
+        bin_heights = F.softmax(bin_heights, dim=-1)
+
+        return [domain_width, bin_widths, bin_heights, *parameters]
+
+    def bin_parameters(self, x: torch.Tensor, xs: torch.Tensor, ys: torch.Tensor, parameters: List[torch.Tensor],
+                       rev: bool = False) -> List[torch.Tensor]:
+        """
+        Sort Parameters into bins, returning left and right edges for each.
+        Inputs that are outside the spline domain are not binned.
+        Also returns which parameters are inside the spline domain.
+        """
+        # determine which inputs are inside the spline domain
+        # i.e. between the first and last bin
+        if not rev:
+            inside = (xs[..., 0] < x) & (x <= xs[..., -1])
+        else:
+            y = x
+            inside = (ys[..., 0] < y) & (y <= ys[..., -1])
+
+        #
+        x = x[inside]
+        xs = xs[inside]
+        ys = ys[inside]
+        parameters = [p[inside] for p in parameters]
+
+        # find upper and lower bin edge indices
+        if not rev:
+            upper = torch.searchsorted(xs, x[..., None])
+            lower = upper - 1
+        else:
+            y = x
+            upper = torch.searchsorted(ys, y[..., None])
+            lower = upper - 1
+
+        left_edge = torch.gather(xs, dim=-1, index=lower).squeeze(-1)
+        right_edge = torch.gather(xs, dim=-1, index=upper).squeeze(-1)
+        bottom_edge = torch.gather(ys, dim=-1, index=lower).squeeze(-1)
+        top_edge = torch.gather(ys, dim=-1, index=upper).squeeze(-1)
+
+        pleft = [torch.gather(p, dim=-1, index=lower).squeeze(-1) for p in parameters]
+        pright = [torch.gather(p, dim=-1, index=upper).squeeze(-1) for p in parameters]
+
+        # interleave pleft and pright
+        parameters = list(chain.from_iterable(zip(pleft, pright)))
+
+        return [inside, left_edge, right_edge, bottom_edge, top_edge, *parameters]
+
+    def _coupling1(self, x1: torch.Tensor, u2: torch.Tensor, rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        The full coupling consists of:
+        - Querying Parameters from the subnetwork
+        - Transforming the unconstrained parameters into bin parameters and spline parameters
+        - Performing the actual spline
+        """
+        parameters = self.subnet1(u2)
+        parameters = self.split_parameters(parameters, self.split_len1)
+        parameters = self.constrain_parameters(parameters)
+
+        domain_width, bin_widths, bin_heights, *parameters = parameters
+
+        xs, ys = make_knots(domain_width, bin_widths, bin_heights)
+
+        inside, left, right, bottom, top, *parameters = self.bin_parameters(x1, xs, ys, parameters, rev=rev)
+
+        assert isinstance(parameters, List)
+        assert all([isinstance(p, torch.Tensor) for p in parameters])
+
+        return binned_spline(
+            x1,
+            inside=inside,
+            left=left,
+            right=right,
+            bottom=bottom,
+            top=top,
+            spline=self.spline1,
+            spline_parameters=parameters,
+            rev=rev,
+        )
+
+    def _coupling2(self, x2: torch.Tensor, u1: torch.Tensor, rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+        parameters = self.subnet2(u1)
+        parameters = self.split_parameters(parameters, self.split_len2)
+        parameters = self.constrain_parameters(parameters)
+
+        domain_width, bin_widths, bin_heights, *parameters = parameters
+
+        xs, ys = make_knots(domain_width, bin_widths, bin_heights)
+
+        inside, left, right, bottom, top, *parameters = self.bin_parameters(x2, xs, ys, parameters, rev=rev)
+
+        assert isinstance(parameters, List)
+        assert all([isinstance(p, torch.Tensor) for p in parameters])
+
+        return binned_spline(
+            x2,
+            inside=inside,
+            left=left,
+            right=right,
+            bottom=bottom,
+            top=top,
+            spline=self.spline2,
+            spline_parameters=parameters,
+            rev=rev,
+        )
+
+
+def binned_spline(x: torch.Tensor, *, inside: torch.Tensor, left: torch.Tensor, right: torch.Tensor,
+                  bottom: torch.Tensor, top: torch.Tensor, spline: callable,
+                  spline_parameters: List[torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Compute a binned spline with identity tails
+    Args:
+        x: input tensor
+        inside: which inputs are inside the spline domain
+        left: left bin edges for inputs inside the spline domain
+        right: same as left
+        bottom: same as left
+        top: same as left
+        spline: the spline function
+        spline_parameters: extra parameters for the spline function
+        rev: whether to run in reverse
+
+    Returns:
+        splined output tensor
+        log jacobian determinant
+    """
+    # identity tails
+    out = torch.clone(x)
+    log_jac = out.new_zeros(out.shape)
+
+    # print(f"{out.shape=}, {log_jac.shape=}, {inside.shape=}, {spline_out.shape=}, {spline_log_jac.shape=}, {x[inside].shape=}")
+
+    # overwrite inside with spline
+    out[inside], log_jac[inside] = spline(x[inside], left, right, bottom, top, spline_parameters, rev=rev)
+
+    # the determinant is given by the sum
+    log_jac_det = utils.sum_except_batch(log_jac)
+
+    if rev:
+        log_jac_det = -log_jac_det
+
+    return out, log_jac_det
+
+
+def make_knots(domain_width: torch.Tensor,
+               bin_widths: torch.Tensor,
+               bin_heights: torch.Tensor,
+               ) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Find bin knots (x and y coordinates) from constrained parameters
+    Args:
+        domain_width: half-width of the zero-centered spline box
+        bin_widths: relative widths of each bin
+        bin_heights: relative heights of each bin
+
+    Returns:
+        tuple containing bin knot x and y coordinates
+    """
+
+    xs = torch.cumsum(bin_widths, dim=-1)
+    pad = xs.new_zeros((*xs.shape[:-1], 1))
+    xs = torch.cat((pad, xs), dim=-1)
+    xs = 2 * domain_width * xs - domain_width
+
+    ys = torch.cumsum(bin_heights, dim=-1)
+    pad = ys.new_zeros((*ys.shape[:-1], 1))
+    ys = torch.cat((pad, ys), dim=-1)
+    ys = 2 * domain_width * ys - domain_width
+
+    return xs, ys

--- a/FrEIA/modules/splines/binned.py
+++ b/FrEIA/modules/splines/binned.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import torch
@@ -16,229 +16,197 @@ class BinnedSpline(_BaseCouplingBlock):
     Implements input-binning, where bin knots are jointly predicted along with spline parameters
     by a non-invertible coupling subnetwork
     """
+
     def __init__(self, dims_in, dims_c=None, subnet_constructor: callable = None, split_len: Union[float, int] = 0.5,
-                 bins: int = 10, parameter_counts: List[int] = None):
+                 bins: int = 10, parameter_counts: Dict[str, int] = None, min_bin_sizes: Tuple[float] = (0.1, 0.1),
+                 default_domain: Tuple[float] = (-3.0, 3.0, -3.0, 3.0)) -> None:
+        """
+        Args:
+            bins: number of bins to use
+            parameter_counts: dictionary containing (parameter_name, parameter_counts)
+                the counts are used to split the network outputs
+            min_bin_sizes: tuple of (min_x_size, min_y_size)
+                bins are scaled such that they never fall below this size
+            default_domain: tuple of (left, right, bottom, top) default spline domain values
+                these values will be used as the starting domain (when the network outputs zero)
+        """
         if dims_c is None:
             dims_c = []
         if parameter_counts is None:
-            parameter_counts = [1, bins, bins]
+            parameter_counts = {}
 
         super().__init__(dims_in, dims_c, clamp=0.0, clamp_activation=lambda u: u, split_len=split_len)
 
-        num_params = sum(parameter_counts)
+        assert bins >= 1, "need at least one bin"
+        assert all(s >= 0 for s in min_bin_sizes), "minimum bin size cannot be negative"
+        assert default_domain[1] > default_domain[0], "x domain must be increasing"
+        assert default_domain[3] > default_domain[2], "y domain must be increasing"
+
+        self.register_buffer("bins", torch.tensor(bins, dtype=torch.int32))
+        self.register_buffer("min_bin_sizes", torch.as_tensor(min_bin_sizes, dtype=torch.float32))
+        self.register_buffer("default_domain", torch.as_tensor(default_domain, dtype=torch.float32))
+
+        # The default parameters are
+        #       parameter                                       constraints             count
+        # 1.    the leftmost bin edge                           -                       1
+        # 2.    the lowermost bin edge                          -                       1
+        # 3.    the widths of each bin                          positive                #bins
+        # 4.    the heights of each bin                         positive                #bins
+        default_parameter_counts = dict(
+            left=1,
+            bottom=1,
+            widths=self.bins,
+            heights=self.bins,
+        )
+        # merge parameter counts with child classes
+        parameter_counts = default_parameter_counts | parameter_counts
+
+        self.parameter_counts = parameter_counts
+
+        num_params = sum(parameter_counts.values())
         self.subnet1 = subnet_constructor(self.split_len2 + self.condition_length, self.split_len1 * num_params)
         self.subnet2 = subnet_constructor(self.split_len1 + self.condition_length, self.split_len2 * num_params)
 
-        self.bins = bins
-        self.parameter_counts = parameter_counts
-
-    def spline1(self, x: torch.Tensor, left: torch.Tensor, right: torch.Tensor, bottom: torch.Tensor, top: torch.Tensor,
-                parameters: List[torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
-        """
-        Perform the actual spline. Callees need to implement this method.
-        Args:
-            x: Inputs within the spline domain
-            left: Bin edge to the left of each input
-            right: Bin edge to the right of each input
-            bottom: Bin edge below each input
-            top: Bin edge above each input
-            parameters: Additional spline parameters
-            rev: whether to run in reverse
-
-        Returns:
-            splined output tensor
-            log jacobian matrix entries for splined inputs
-        """
+    def _spline1(self, x1: torch.Tensor, parameters: Dict[str, torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError
 
-    def spline2(self, x: torch.Tensor, left: torch.Tensor, right: torch.Tensor, bottom: torch.Tensor, top: torch.Tensor,
-                parameters: List[torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+    def _spline2(self, x2: torch.Tensor, parameters: Dict[str, torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError
-
-    def split_parameters(self, parameters: torch.Tensor, split_len: int) -> List[torch.Tensor]:
-        """
-        Split network output into semantic parameters, as given by self.parameter_counts
-        """
-        parameters = parameters.movedim(1, -1)
-        parameters = parameters.reshape(*parameters.shape[:-1], split_len, -1)
-        return list(torch.split(parameters, self.parameter_counts, dim=-1))
-
-    def constrain_parameters(self, parameters: List[torch.Tensor]) -> List[torch.Tensor]:
-        """
-        Constrain Parameters to meet certain conditions (e.g. positivity)
-        """
-        domain_width, bin_widths, bin_heights, *parameters = parameters
-
-        # constrain the domain width to positive values
-        # use a shifted softplus
-        shift = np.log(np.e - 1)
-        domain_width = F.softplus(domain_width + shift)
-
-        # bin widths must be positive and sum to 1
-        bin_widths = F.softmax(bin_widths, dim=-1)
-
-        # same for the bin heights
-        bin_heights = F.softmax(bin_heights, dim=-1)
-
-        return [domain_width, bin_widths, bin_heights, *parameters]
-
-    def bin_parameters(self, x: torch.Tensor, xs: torch.Tensor, ys: torch.Tensor, parameters: List[torch.Tensor],
-                       rev: bool = False) -> List[torch.Tensor]:
-        """
-        Sort Parameters into bins, returning left and right edges for each.
-        Inputs that are outside the spline domain are not binned.
-        Also returns which parameters are inside the spline domain.
-        """
-        # determine which inputs are inside the spline domain
-        # i.e. between the first and last bin
-        if not rev:
-            inside = (xs[..., 0] < x) & (x <= xs[..., -1])
-        else:
-            y = x
-            inside = (ys[..., 0] < y) & (y <= ys[..., -1])
-
-        #
-        x = x[inside]
-        xs = xs[inside]
-        ys = ys[inside]
-        parameters = [p[inside] for p in parameters]
-
-        # find upper and lower bin edge indices
-        if not rev:
-            upper = torch.searchsorted(xs, x[..., None])
-            lower = upper - 1
-        else:
-            y = x
-            upper = torch.searchsorted(ys, y[..., None])
-            lower = upper - 1
-
-        left_edge = torch.gather(xs, dim=-1, index=lower).squeeze(-1)
-        right_edge = torch.gather(xs, dim=-1, index=upper).squeeze(-1)
-        bottom_edge = torch.gather(ys, dim=-1, index=lower).squeeze(-1)
-        top_edge = torch.gather(ys, dim=-1, index=upper).squeeze(-1)
-
-        pleft = [torch.gather(p, dim=-1, index=lower).squeeze(-1) for p in parameters]
-        pright = [torch.gather(p, dim=-1, index=upper).squeeze(-1) for p in parameters]
-
-        # interleave pleft and pright
-        parameters = list(chain.from_iterable(zip(pleft, pright)))
-
-        return [inside, left_edge, right_edge, bottom_edge, top_edge, *parameters]
 
     def _coupling1(self, x1: torch.Tensor, u2: torch.Tensor, rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         The full coupling consists of:
-        - Querying Parameters from the subnetwork
-        - Transforming the unconstrained parameters into bin parameters and spline parameters
-        - Performing the actual spline
+        1. Querying the parameter tensor from the subnetwork
+        2. Splitting this tensor into the semantic parameters
+        3. Constraining the parameters
+        4. Performing the actual spline for each bin, given the parameters
         """
         parameters = self.subnet1(u2)
         parameters = self.split_parameters(parameters, self.split_len1)
         parameters = self.constrain_parameters(parameters)
 
-        domain_width, bin_widths, bin_heights, *parameters = parameters
-
-        xs, ys = make_knots(domain_width, bin_widths, bin_heights)
-
-        inside, left, right, bottom, top, *parameters = self.bin_parameters(x1, xs, ys, parameters, rev=rev)
-
-        return binned_spline(
-            x1,
-            inside=inside,
-            left=left,
-            right=right,
-            bottom=bottom,
-            top=top,
-            spline=self.spline1,
-            spline_parameters=parameters,
-            rev=rev,
-        )
+        return self.binned_spline(x=x1, parameters=parameters, spline=self._spline1, rev=rev)
 
     def _coupling2(self, x2: torch.Tensor, u1: torch.Tensor, rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
         parameters = self.subnet2(u1)
         parameters = self.split_parameters(parameters, self.split_len2)
         parameters = self.constrain_parameters(parameters)
 
-        domain_width, bin_widths, bin_heights, *parameters = parameters
+        return self.binned_spline(x=x2, parameters=parameters, spline=self._spline2, rev=rev)
 
-        xs, ys = make_knots(domain_width, bin_widths, bin_heights)
+    def split_parameters(self, parameters: torch.Tensor, split_len: int) -> Dict[str, torch.Tensor]:
+        """
+        Split network output into semantic parameters, as given by self.parameter_counts
+        """
+        parameters = parameters.movedim(1, -1)
+        parameters = parameters.reshape(*parameters.shape[:-1], split_len, -1)
 
-        inside, left, right, bottom, top, *parameters = self.bin_parameters(x2, xs, ys, parameters, rev=rev)
+        keys = list(self.parameter_counts.keys())
+        values = list(torch.split(parameters, list(self.parameter_counts.values()), dim=-1))
 
-        return binned_spline(
-            x2,
-            inside=inside,
-            left=left,
-            right=right,
-            bottom=bottom,
-            top=top,
-            spline=self.spline2,
-            spline_parameters=parameters,
-            rev=rev,
-        )
+        return dict(zip(keys, values))
 
+    def constrain_parameters(self, parameters: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        """
+        Constrain Parameters to meet certain conditions (e.g. positivity)
+        """
+        # we constrain the widths and heights to be positive with a softplus
+        # furthermore, to allow minimum bin widths, we add this outside the softplus
+        # we also want to use the default domain when the network predicts zeros, so
+        # shift the softplus such that this is true, even with nonzero minimum bin sizes.
+        parameters["left"] = parameters["left"] + self.default_domain[0]
+        parameters["bottom"] = parameters["bottom"] + self.default_domain[2]
 
-def binned_spline(x: torch.Tensor, *, inside: torch.Tensor, left: torch.Tensor, right: torch.Tensor,
-                  bottom: torch.Tensor, top: torch.Tensor, spline: callable,
-                  spline_parameters: List[torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Compute a binned spline with identity tails
-    Args:
-        x: input tensor
-        inside: which inputs are inside the spline domain
-        left: left bin edges for inputs inside the spline domain
-        right: same as left
-        bottom: same as left
-        top: same as left
-        spline: the spline function
-        spline_parameters: extra parameters for the spline function
-        rev: whether to run in reverse
+        default_width = self.default_domain[1] - self.default_domain[0]
+        default_height = self.default_domain[3] - self.default_domain[2]
 
-    Returns:
-        splined output tensor
-        log jacobian determinant
-    """
-    # identity tails
-    out = torch.clone(x)
-    log_jac = out.new_zeros(out.shape)
+        xshift = torch.log(torch.exp(default_width - self.min_bin_sizes[0]) - 1)
+        yshift = torch.log(torch.exp(default_height - self.min_bin_sizes[1]) - 1)
 
-    # print(f"{out.shape=}, {log_jac.shape=}, {inside.shape=}, {spline_out.shape=}, {spline_log_jac.shape=}, {x[inside].shape=}")
+        parameters["widths"] = self.min_bin_sizes[0] + F.softplus(parameters["widths"] + xshift)
+        parameters["heights"] = self.min_bin_sizes[1] + F.softplus(parameters["heights"] + yshift)
 
-    # overwrite inside with spline
-    out[inside], log_jac[inside] = spline(x[inside], left, right, bottom, top, spline_parameters, rev=rev)
+        return parameters
 
-    # the determinant is given by the sum
-    log_jac_det = utils.sum_except_batch(log_jac)
+    def binned_spline(self, x: torch.Tensor, parameters: Dict[str, torch.Tensor], spline: callable, rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Compute the spline for given bin and spline parameters
+        """
+        # find bin knots
+        knot_x = parameters["left"] + torch.cumsum(parameters["widths"], dim=-1)
+        knot_y = parameters["bottom"] + torch.cumsum(parameters["heights"], dim=-1)
 
-    if rev:
-        log_jac_det = -log_jac_det
+        # concatenate leftmost edge
+        knot_x = torch.cat((parameters["left"], knot_x), dim=-1)
+        knot_y = torch.cat((parameters["bottom"], knot_y), dim=-1)
 
-    return out, log_jac_det
+        # find spline mask
+        if not rev:
+            inside = (knot_x[..., 0] < x) & (x <= knot_x[..., -1])
+        else:
+            y = x
+            inside = (knot_y[..., 0] < y) & (y <= knot_x[..., -1])
 
+        knot_x = knot_x[inside]
+        knot_y = knot_y[inside]
 
-def make_knots(domain_width: torch.Tensor,
-               bin_widths: torch.Tensor,
-               bin_heights: torch.Tensor,
-               ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Find bin knots (x and y coordinates) from constrained parameters
-    Args:
-        domain_width: half-width of the zero-centered spline box
-        bin_widths: relative widths of each bin
-        bin_heights: relative heights of each bin
+        x_in = x[inside]
+        x_out = x[~inside]
 
-    Returns:
-        tuple containing bin knot x and y coordinates
-    """
+        scale = torch.sum(parameters["heights"], dim=-1, keepdim=True) / torch.sum(parameters["widths"], dim=-1, keepdim=True)
+        shift = parameters["bottom"] - scale * parameters["left"]
 
-    xs = torch.cumsum(bin_widths, dim=-1)
-    pad = xs.new_zeros((*xs.shape[:-1], 1))
-    xs = torch.cat((pad, xs), dim=-1)
-    xs = 2 * domain_width * xs - domain_width
+        scale = scale[~inside].squeeze(-1)
+        shift = shift[~inside].squeeze(-1)
 
-    ys = torch.cumsum(bin_heights, dim=-1)
-    pad = ys.new_zeros((*ys.shape[:-1], 1))
-    ys = torch.cat((pad, ys), dim=-1)
-    ys = 2 * domain_width * ys - domain_width
+        # find bin edge indices
+        if not rev:
+            upper = torch.searchsorted(knot_x, x_in[..., None])
+        else:
+            y_in = x_in
+            upper = torch.searchsorted(knot_y, y_in[..., None])
 
-    return xs, ys
+        lower = upper - 1
+
+        spline_parameters = dict()
+
+        # gather bin edges from indices
+        spline_parameters["left"] = torch.gather(knot_x, dim=-1, index=lower).squeeze(-1)
+        spline_parameters["right"] = torch.gather(knot_x, dim=-1, index=upper).squeeze(-1)
+        spline_parameters["bottom"] = torch.gather(knot_y, dim=-1, index=lower).squeeze(-1)
+        spline_parameters["top"] = torch.gather(knot_y, dim=-1, index=upper).squeeze(-1)
+
+        # gather all other parameter edges
+        for key, value in parameters.items():
+            if key in ["left", "bottom", "widths", "heights"]:
+                continue
+
+            v = value[inside]
+
+            spline_parameters[f"{key}_left"] = torch.gather(v, dim=-1, index=lower).squeeze(-1)
+            spline_parameters[f"{key}_right"] = torch.gather(v, dim=-1, index=upper).squeeze(-1)
+
+        if not rev:
+            y = torch.clone(x)
+            log_jac = y.new_zeros(y.shape)
+
+            y[inside], log_jac[inside] = spline(x_in, spline_parameters, rev=rev)
+            y[~inside], log_jac[~inside] = scale * x_out + shift, torch.log(scale)
+
+            log_jac_det = utils.sum_except_batch(log_jac)
+
+            return y, log_jac_det
+        else:
+            y = x
+            y_in = x_in
+            y_out = x_out
+
+            x = torch.clone(y)
+            log_jac = x.new_zeros(x.shape)
+
+            x[inside], log_jac[inside] = spline(y_in, spline_parameters, rev=rev)
+            x[~inside], log_jac[~inside] = (y_out - shift) / scale, torch.log(scale)
+
+            log_jac_det = -utils.sum_except_batch(log_jac)
+
+            return x, log_jac_det

--- a/FrEIA/modules/splines/binned.py
+++ b/FrEIA/modules/splines/binned.py
@@ -142,9 +142,6 @@ class BinnedSpline(_BaseCouplingBlock):
 
         inside, left, right, bottom, top, *parameters = self.bin_parameters(x1, xs, ys, parameters, rev=rev)
 
-        assert isinstance(parameters, List)
-        assert all([isinstance(p, torch.Tensor) for p in parameters])
-
         return binned_spline(
             x1,
             inside=inside,
@@ -167,9 +164,6 @@ class BinnedSpline(_BaseCouplingBlock):
         xs, ys = make_knots(domain_width, bin_widths, bin_heights)
 
         inside, left, right, bottom, top, *parameters = self.bin_parameters(x2, xs, ys, parameters, rev=rev)
-
-        assert isinstance(parameters, List)
-        assert all([isinstance(p, torch.Tensor) for p in parameters])
 
         return binned_spline(
             x2,

--- a/FrEIA/modules/splines/linear.py
+++ b/FrEIA/modules/splines/linear.py
@@ -1,0 +1,68 @@
+from typing import Tuple
+
+import torch
+
+from .binned import BinnedSpline
+
+
+class LinearSpline(BinnedSpline):
+    def __init__(self, *args, bins: int = 10, **kwargs):
+        #       parameter                           constraints             count
+        # 1.    the domain half-width B             positive                1
+        # 2.    the relative width of each bin      positive, sum to 1      #bins
+        # 3.    the relative height of each bin     positive, sum to 1      #bins
+        super().__init__(*args, **kwargs, bins=bins, parameter_counts=[1, bins, bins])
+
+    def spline1(self,
+                x: torch.Tensor,
+                left: torch.Tensor,
+                right: torch.Tensor,
+                bottom: torch.Tensor,
+                top: torch.Tensor,
+                *params: torch.Tensor,
+                rev: bool = False,
+                ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return linear_spline(x, left, right, bottom, top, rev=rev)
+
+    def spline2(self,
+                x: torch.Tensor,
+                left: torch.Tensor,
+                right: torch.Tensor,
+                bottom: torch.Tensor,
+                top: torch.Tensor,
+                *params: torch.Tensor,
+                rev: bool = False,
+                ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return linear_spline(x, left, right, bottom, top, rev=rev)
+
+
+def linear_spline(x: torch.Tensor, left: torch.Tensor, right: torch.Tensor, bottom: torch.Tensor, top: torch.Tensor,
+                  rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Computes a linear spline, connecting each knot with a straight line
+    Args:
+        x: input tensor
+        left: left bin edges for inputs inside the spline domain
+        right: same as left
+        bottom: same as left
+        top: same as left
+        rev: whether to run in reverse
+
+    Returns:
+        splined output tensor
+        log jacobian matrix entries
+    """
+    dx = right - left
+    dy = top - bottom
+
+    a = dy / dx
+    b = bottom - a * left
+
+    if not rev:
+        out = a * x + b
+    else:
+        out = (x - b) / a
+
+    log_jac = torch.log(dy) - torch.log(dx)
+
+    return out, log_jac

--- a/FrEIA/modules/splines/rational_quadratic.py
+++ b/FrEIA/modules/splines/rational_quadratic.py
@@ -1,0 +1,117 @@
+from typing import Tuple, List
+
+import torch
+import torch.nn.functional as F
+import numpy as np
+
+from .binned import BinnedSpline
+
+
+class RationalQuadraticSpline(BinnedSpline):
+    def __init__(self, *args, bins: int = 10, **kwargs):
+        #       parameter                                       constraints             count
+        # 1.    the domain half-width B                         positive                1
+        # 2.    the relative width of each bin                  positive, sum to 1      #bins
+        # 3.    the relative height of each bin                 positive, sum to 1      #bins
+        # 4.    the derivative at the edge of each inner bin    positive                #bins - 1
+        super().__init__(*args, **kwargs, bins=bins, parameter_counts=[1, bins, bins, bins - 1])
+
+    def constrain_parameters(self, parameters: List[torch.Tensor]) -> List[torch.Tensor]:
+        deltas = parameters[3]
+        # shifted softplus such that network output 0 -> delta = 1
+        shift = np.log(np.e - 1)
+        deltas = F.softplus(deltas + shift)
+
+        # boundary condition: derivative is one at spline boundaries
+        pad = deltas.new_ones((*deltas.shape[:-1], 2))
+        deltas = torch.cat((deltas, pad), dim=-1).roll(1, dims=-1)
+
+        parameters[3] = deltas
+
+        return super().constrain_parameters(parameters)
+
+    def spline1(self, x: torch.Tensor, left: torch.Tensor, right: torch.Tensor, bottom: torch.Tensor, top: torch.Tensor,
+                parameters: List[torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+        assert isinstance(parameters, List)
+        assert all([isinstance(p, torch.Tensor) for p in parameters])
+        delta_left, delta_right = parameters
+        return rational_quadratic_spline(x, left, right, bottom, top, delta_left, delta_right, rev=rev)
+
+    def spline2(self, x: torch.Tensor, left: torch.Tensor, right: torch.Tensor, bottom: torch.Tensor, top: torch.Tensor,
+                parameters: List[torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+        delta_left, delta_right = parameters
+        return rational_quadratic_spline(x, left, right, bottom, top, delta_left, delta_right, rev=rev)
+
+
+def rational_quadratic_spline(x: torch.Tensor,
+                              left: torch.Tensor,
+                              right: torch.Tensor,
+                              bottom: torch.Tensor,
+                              top: torch.Tensor,
+                              delta_left: torch.Tensor,
+                              delta_right: torch.Tensor,
+                              rev: bool = False,
+                              ) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Compute the rational-quadratic spline with the algorithm described in arXiv:1906.04032
+    Forward output is defined for each bin by the fraction
+    ..math::
+        z = f(x) = \\frac{ \\beta_0 + \\beta_1 x + \\beta_2 x^2 }{ 1 + \\beta_3 x + \\beta_4 x^2 }
+
+    where the \\beta are constrained to yield a smooth function over all bins
+    Args:
+        x: input tensor
+        left: left bin edges for inputs inside the spline domain
+        right: same as left
+        bottom: same as left
+        top: same as left
+        delta_left: spline derivatives at the left and bottom bin edge
+        delta_right: spline derivatives at the right and top bin edge
+        rev: whether to run in reverse
+
+    Returns:
+        splined output tensor
+        log jacobian matrix entries
+    """
+    # rename variables to match the paper:
+    # xk means $x_k$ and xkp means $x_{k+1}$
+    xk = left
+    xkp = right
+    yk = bottom
+    ykp = top
+    dk = delta_left
+    dkp = delta_right
+
+    # define some commonly used values
+    dx = xkp - xk
+    dy = ykp - yk
+    sk = dy / dx
+
+    if not rev:
+        xi = (x - xk) / dx
+
+        # Eq 4 in the paper
+        numerator = dy * (sk * xi ** 2 + dk * xi * (1 - xi))
+        denominator = sk + (dkp + dk - 2 * sk) * xi * (1 - xi)
+        out = yk + numerator / denominator
+    else:
+        y = x
+        # Eq 6-8 in the paper
+        a = dy * (sk - dk) + (y - yk) * (dkp + dk - 2 * sk)
+        b = dy * dk - (y - yk) * (dkp + dk - 2 * sk)
+        c = -sk * (y - yk)
+
+        # Eq 29 in the appendix of the paper
+        discriminant = b ** 2 - 4 * a * c
+        assert torch.all(discriminant >= 0)
+
+        xi = 2 * c / (-b - torch.sqrt(discriminant))
+
+        out = xi * dx + xk
+
+    # Eq 5 in the paper
+    numerator = sk ** 2 * (dkp * xi ** 2 + 2 * sk * xi * (1 - xi) + dk * (1 - xi) ** 2)
+    denominator = (sk + (dkp + dk - 2 * sk) * xi * (1 - xi)) ** 2
+    log_jac = torch.log(numerator) - torch.log(denominator)
+
+    return out, log_jac

--- a/FrEIA/modules/splines/rational_quadratic.py
+++ b/FrEIA/modules/splines/rational_quadratic.py
@@ -32,8 +32,6 @@ class RationalQuadraticSpline(BinnedSpline):
 
     def spline1(self, x: torch.Tensor, left: torch.Tensor, right: torch.Tensor, bottom: torch.Tensor, top: torch.Tensor,
                 parameters: List[torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
-        assert isinstance(parameters, List)
-        assert all([isinstance(p, torch.Tensor) for p in parameters])
         delta_left, delta_right = parameters
         return rational_quadratic_spline(x, left, right, bottom, top, delta_left, delta_right, rev=rev)
 

--- a/FrEIA/modules/splines/rational_quadratic.py
+++ b/FrEIA/modules/splines/rational_quadratic.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List
+from typing import Dict, List, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -10,35 +10,38 @@ from .binned import BinnedSpline
 class RationalQuadraticSpline(BinnedSpline):
     def __init__(self, *args, bins: int = 10, **kwargs):
         #       parameter                                       constraints             count
-        # 1.    the domain half-width B                         positive                1
-        # 2.    the relative width of each bin                  positive, sum to 1      #bins
-        # 3.    the relative height of each bin                 positive, sum to 1      #bins
-        # 4.    the derivative at the edge of each inner bin    positive                #bins - 1
-        super().__init__(*args, **kwargs, bins=bins, parameter_counts=[1, bins, bins, bins - 1])
+        # 1.    the derivative at the edge of each inner bin    positive                #bins - 1
+        super().__init__(*args, **kwargs, bins=bins, parameter_counts={"deltas": bins - 1})
 
-    def constrain_parameters(self, parameters: List[torch.Tensor]) -> List[torch.Tensor]:
-        deltas = parameters[3]
-        # shifted softplus such that network output 0 -> delta = 1
+    def constrain_parameters(self, parameters: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        parameters = super().constrain_parameters(parameters)
+        # we additionally want positive derivatives to preserve monotonicity
+        # the derivative must also match the tails at the spline boundaries
+        deltas = parameters["deltas"]
+
+        # shifted softplus such that network output 0 -> delta = scale
         shift = np.log(np.e - 1)
         deltas = F.softplus(deltas + shift)
 
-        # boundary condition: derivative is one at spline boundaries
-        pad = deltas.new_ones((*deltas.shape[:-1], 2))
-        deltas = torch.cat((deltas, pad), dim=-1).roll(1, dims=-1)
+        # boundary condition: derivative is equal to affine scale at spline boundaries
+        scale = torch.sum(parameters["heights"], dim=-1, keepdim=True) / torch.sum(parameters["widths"], dim=-1, keepdim=True)
+        scale = scale.expand(*scale.shape[:-1], 2)
 
-        parameters[3] = deltas
+        deltas = torch.cat((deltas, scale), dim=-1).roll(1, dims=-1)
 
-        return super().constrain_parameters(parameters)
+        parameters["deltas"] = deltas
 
-    def spline1(self, x: torch.Tensor, left: torch.Tensor, right: torch.Tensor, bottom: torch.Tensor, top: torch.Tensor,
-                parameters: List[torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
-        delta_left, delta_right = parameters
-        return rational_quadratic_spline(x, left, right, bottom, top, delta_left, delta_right, rev=rev)
+        return parameters
 
-    def spline2(self, x: torch.Tensor, left: torch.Tensor, right: torch.Tensor, bottom: torch.Tensor, top: torch.Tensor,
-                parameters: List[torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
-        delta_left, delta_right = parameters
-        return rational_quadratic_spline(x, left, right, bottom, top, delta_left, delta_right, rev=rev)
+    def _spline1(self, x: torch.Tensor, parameters: Dict[str, torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+        left, right, bottom, top = parameters["left"], parameters["right"], parameters["bottom"], parameters["top"]
+        deltas_left, deltas_right = parameters["deltas_left"], parameters["deltas_right"]
+        return rational_quadratic_spline(x, left, right, bottom, top, deltas_left, deltas_right, rev=rev)
+
+    def _spline2(self, x: torch.Tensor, parameters: Dict[str, torch.Tensor], rev: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+        left, right, bottom, top = parameters["left"], parameters["right"], parameters["bottom"], parameters["top"]
+        deltas_left, deltas_right = parameters["deltas_left"], parameters["deltas_right"]
+        return rational_quadratic_spline(x, left, right, bottom, top, deltas_left, deltas_right, rev=rev)
 
 
 def rational_quadratic_spline(x: torch.Tensor,
@@ -46,8 +49,8 @@ def rational_quadratic_spline(x: torch.Tensor,
                               right: torch.Tensor,
                               bottom: torch.Tensor,
                               top: torch.Tensor,
-                              delta_left: torch.Tensor,
-                              delta_right: torch.Tensor,
+                              deltas_left: torch.Tensor,
+                              deltas_right: torch.Tensor,
                               rev: bool = False,
                               ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
@@ -63,8 +66,8 @@ def rational_quadratic_spline(x: torch.Tensor,
         right: same as left
         bottom: same as left
         top: same as left
-        delta_left: spline derivatives at the left and bottom bin edge
-        delta_right: spline derivatives at the right and top bin edge
+        deltas_left: spline derivatives at the left and bottom bin edge
+        deltas_right: spline derivatives at the right and top bin edge
         rev: whether to run in reverse
 
     Returns:
@@ -77,8 +80,8 @@ def rational_quadratic_spline(x: torch.Tensor,
     xkp = right
     yk = bottom
     ykp = top
-    dk = delta_left
-    dkp = delta_right
+    dk = deltas_left
+    dkp = deltas_right
 
     # define some commonly used values
     dx = xkp - xk

--- a/FrEIA/utils.py
+++ b/FrEIA/utils.py
@@ -1,0 +1,24 @@
+import torch
+
+from typing import Callable
+
+
+def f_except(f: Callable, x: torch.Tensor, *dim, **kwargs):
+    """ Apply f on all dimensions except those specified in dim """
+    result = x
+    dimensions = [d for d in range(x.dim()) if d not in dim]
+
+    if not dimensions:
+        raise ValueError(f"Cannot exclude dims {dim} from x with shape {x.shape}: No dimensions left.")
+
+    return f(result, dim=dimensions, **kwargs)
+
+
+def sum_except(x: torch.Tensor, *dim):
+    """ Sum all dimensions of x except the ones specified in dim """
+    return f_except(torch.sum, x, *dim)
+
+
+def sum_except_batch(x):
+    """ Sum all dimensions of x except the first (batch) dimension """
+    return sum_except(x, 0)


### PR DESCRIPTION
This PR adds two new coupling blocks:
1. a `LinearSpline` that connects knots with a straight line
2. a `RationalQuadraticSpline` as described in [arXiv:1906.04032](https://arxiv.org/abs/1906.04032).

Both derive from a common base class `BinnedSpline` which allows for an easy implementation of new splines that use a network-predicted binning. The `RationalQuadraticSpline` has two minor differences to the paper:
1. The spline is superimposed with an affine function, replacing the identity tails
2. The spline boundary is predicted by the subnetwork, instead of being a hyper-parameter.

Splines are implemented in native PyTorch with no dependencies beyond the existing ones. All changes are backward-compatible.