### PR TITLE
Fix Invalid Dict Merging in BinnedSpline for Python < 3.9

### DIFF
--- a/FrEIA/modules/splines/binned.py
+++ b/FrEIA/modules/splines/binned.py
@@ -55,15 +55,13 @@ class BinnedSpline(_BaseCouplingBlock):
         default_parameter_counts = dict(
             left=1,
             bottom=1,
-            widths=self.bins,
-            heights=self.bins,
+            widths=bins,
+            heights=bins,
         )
         # merge parameter counts with child classes
-        parameter_counts = default_parameter_counts | parameter_counts
+        self.parameter_counts = {**default_parameter_counts, **parameter_counts}
 
-        self.parameter_counts = parameter_counts
-
-        num_params = sum(parameter_counts.values())
+        num_params = sum(self.parameter_counts.values())
         self.subnet1 = subnet_constructor(self.split_len2 + self.condition_length, self.split_len1 * num_params)
         self.subnet2 = subnet_constructor(self.split_len1 + self.condition_length, self.split_len2 * num_params)
 


### PR DESCRIPTION
#129 contained invalid syntax in merging the parameter count dictionaries for Python Versions < 3.9. This PR fixes that.