### PR TITLE
Added identity tails option to BinnedSplineBase. Fixed default_domain for initialization

### DIFF
--- a/FrEIA/modules/splines/binned.py
+++ b/FrEIA/modules/splines/binned.py
@@ -87,6 +87,10 @@ class BinnedSplineBase(InvertibleModule):
         assert all(s >= 0 for s in min_bin_sizes), "minimum bin size cannot be negative"
         assert default_domain[1] > default_domain[0], "x domain must be increasing"
         assert default_domain[3] > default_domain[2], "y domain must be increasing"
+        assert default_domain[1] - default_domain[0] >= min_bin_sizes[0] * bins, \
+        "{bins} bins of size {min_bin_sizes[0]} are too large for domain {default_domain[0]} to {default_domain[1]}"
+        assert default_domain[3] - default_domain[2] >= min_bin_sizes[1] * bins, \
+        "{bins} bins of size {min_bin_sizes[1]} are too large for domain {default_domain[2]} to {default_domain[3]}"
 
         self.register_buffer("bins", torch.tensor(bins, dtype=torch.int32))
         self.register_buffer("min_bin_sizes", torch.as_tensor(min_bin_sizes, dtype=torch.float32))
@@ -157,6 +161,7 @@ class BinnedSplineBase(InvertibleModule):
 
             parameters["widths"] = self.min_bin_sizes[0] + F.softplus(parameters["widths"] + xshift)
             parameters["heights"] = self.min_bin_sizes[1] + F.softplus(parameters["heights"] + yshift)
+            
 
         return parameters
 
@@ -173,6 +178,8 @@ class BinnedSplineBase(InvertibleModule):
         # concatenate leftmost edge
         knot_x = torch.cat((parameters["left"], knot_x), dim=-1)
         knot_y = torch.cat((parameters["bottom"], knot_y), dim=-1)
+
+
 
         # find spline mask
         if not rev:

--- a/FrEIA/modules/splines/binned.py
+++ b/FrEIA/modules/splines/binned.py
@@ -180,13 +180,12 @@ class BinnedSplineBase(InvertibleModule):
         knot_y = torch.cat((parameters["bottom"], knot_y), dim=-1)
 
 
-
         # find spline mask
         if not rev:
-            inside = (knot_x[..., 0] < x) & (x <= knot_x[..., -1])
+            inside = (knot_x[..., 0] < x) & (x < knot_x[..., -1])
         else:
             y = x
-            inside = (knot_y[..., 0] < y) & (y <= knot_x[..., -1])
+            inside = (knot_y[..., 0] < y) & (y < knot_x[..., -1])
 
         knot_x = knot_x[inside]
         knot_y = knot_y[inside]

--- a/FrEIA/modules/splines/binned.py
+++ b/FrEIA/modules/splines/binned.py
@@ -182,10 +182,10 @@ class BinnedSplineBase(InvertibleModule):
 
         # find spline mask
         if not rev:
-            inside = (knot_x[..., 0] < x) & (x < knot_x[..., -1])
+            inside = (knot_x[..., 0] < x) & (x <= knot_x[..., -1])
         else:
             y = x
-            inside = (knot_y[..., 0] < y) & (y < knot_x[..., -1])
+            inside = (knot_y[..., 0] < y) & (y <= knot_y[..., -1])
 
         knot_x = knot_x[inside]
         knot_y = knot_y[inside]
@@ -205,7 +205,6 @@ class BinnedSplineBase(InvertibleModule):
         else:
             y_in = x_in
             upper = torch.searchsorted(knot_y, y_in[..., None])
-
         lower = upper - 1
 
         spline_parameters = dict()

--- a/FrEIA/modules/splines/binned.py
+++ b/FrEIA/modules/splines/binned.py
@@ -144,18 +144,16 @@ class BinnedSplineBase(InvertibleModule):
 
             parameters["widths"] = total_width * F.softmax(parameters["widths"], dim=-1)
             parameters["heights"] = total_width * F.softmax(parameters["heights"], dim=-1)
-            parameters["widths"] = torch.log(parameters["widths"])
-            parameters["heights"] = torch.log(parameters["heights"])
 
         else:
             parameters["left"] = parameters["left"] + self.default_domain[0]
             parameters["bottom"] = parameters["bottom"] + self.default_domain[2]
 
-            default_width = self.default_domain[1] - self.default_domain[0]
-            default_height = self.default_domain[3] - self.default_domain[2]
+            default_bin_width = (self.default_domain[1] - self.default_domain[0]) / self.bins
+            default_bin_height = (self.default_domain[3] - self.default_domain[2]) / self.bins
 
-            xshift = torch.log(torch.exp(default_width - self.min_bin_sizes[0]) - 1)
-            yshift = torch.log(torch.exp(default_height - self.min_bin_sizes[1]) - 1)
+            xshift = torch.log(torch.exp(default_bin_width - self.min_bin_sizes[0]) - 1)
+            yshift = torch.log(torch.exp(default_bin_height - self.min_bin_sizes[1]) - 1)
 
             parameters["widths"] = self.min_bin_sizes[0] + F.softplus(parameters["widths"] + xshift)
             parameters["heights"] = self.min_bin_sizes[1] + F.softplus(parameters["heights"] + yshift)
@@ -214,7 +212,7 @@ class BinnedSplineBase(InvertibleModule):
 
         # gather all other parameter edges
         for key, value in parameters.items():
-            if key in ["left", "bottom", "widths", "heights"]:
+            if key in ["left", "bottom", "widths", "heights", "total_width"]:
                 continue
 
             v = value[inside]


### PR DESCRIPTION
- Added the option to fix the spline domain to a 0-centered square domain (which results in identity tails outside of the domain
- Fixed an issue where with `BinnedSplineBase(..., default_domain = (low, high, ...))` the spline domain would be initialized to `(low, bins*(high-low)+low, ...)` instead of `(low, high, ...)`
- Checking `min_bins_size` upon initialization (`bins*min_bin_size` should not exceed `default_domain` width/height)
- This was incorrect and has been reverted: Fixed check for whether a given x is in or out of domain of the spline (`torch.searchsorted` treats equality as out of domain, as opposed to FrEIA which used to treat it as in domain)
- This is the correct fix for out of domain at evaluation time: Using correct knots for inside domain check in reverse direction (`knots_y` instead of `knots_x`)