### PR TITLE
Various module improvements

### DIFF
--- a/FrEIA/modules/all_in_one_block.py
+++ b/FrEIA/modules/all_in_one_block.py
@@ -155,11 +155,11 @@ class AllInOneBlock(InvertibleModule):
             self.vk_householder = nn.Parameter(0.2 * torch.randn(self.householder, channels), requires_grad=True)
             self.w_perm = None
             self.w_perm_inv = None
-            self.w_0 = nn.Parameter(torch.FloatTensor(w), requires_grad=False)
+            self.w_0 = nn.Parameter(torch.from_numpy(w), requires_grad=False)
         elif permute_soft:
-            self.w_perm = nn.Parameter(torch.FloatTensor(w).view(channels, channels, *([1] * self.input_rank)),
+            self.w_perm = nn.Parameter(torch.from_numpy(w).view(channels, channels, *([1] * self.input_rank)).contiguous(),
                                        requires_grad=False)
-            self.w_perm_inv = nn.Parameter(torch.FloatTensor(w.T).view(channels, channels, *([1] * self.input_rank)),
+            self.w_perm_inv = nn.Parameter(torch.from_numpy(w.T).view(channels, channels, *([1] * self.input_rank)).contiguous(),
                                            requires_grad=False)
         else:
             self.w_perm = nn.Parameter(w_index, requires_grad=False)
@@ -239,7 +239,7 @@ class AllInOneBlock(InvertibleModule):
 
     def forward(self, x, c=[], rev=False, jac=True):
         '''See base class docstring'''
-        if x.shape[0][1:] != self.dims_in[0][1:]:
+        if x[0].shape[1:] != self.dims_in[0][1:]:
             raise RuntimeError(f"Expected input of shape {self.dims_in[0]}, "
                              f"got {x.shape}.")
         if self.householder:

--- a/FrEIA/modules/all_in_one_block.py
+++ b/FrEIA/modules/all_in_one_block.py
@@ -147,9 +147,6 @@ class AllInOneBlock(InvertibleModule):
             w = special_ortho_group.rvs(channels)
         else:
             w_index = torch.randperm(channels, requires_grad=False)
-            w = np.zeros((channels, channels))
-            for i, j in enumerate(np.random.permutation(channels)):
-                w[i, j] = 1.
 
         if self.householder:
             # instead of just the permutation matrix w, the learned housholder

--- a/FrEIA/modules/all_in_one_block.py
+++ b/FrEIA/modules/all_in_one_block.py
@@ -239,7 +239,7 @@ class AllInOneBlock(InvertibleModule):
 
     def forward(self, x, c=[], rev=False, jac=True):
         '''See base class docstring'''
-        if x.shape[1:] != self.dims_in[0][1:]:
+        if x.shape[0][1:] != self.dims_in[0][1:]:
             raise RuntimeError(f"Expected input of shape {self.dims_in[0]}, "
                              f"got {x.shape}.")
         if self.householder:

--- a/FrEIA/modules/all_in_one_block.py
+++ b/FrEIA/modules/all_in_one_block.py
@@ -229,7 +229,7 @@ class AllInOneBlock(InvertibleModule):
         a *= 0.1
         ch = x.shape[1]
 
-        sub_jac = self.clamp * torch.tanh(a[:, :ch])
+        sub_jac = self.clamp * torch.tanh(a[:, :ch]/self.clamp)
         if self.GIN:
             sub_jac -= torch.mean(sub_jac, dim=self.sum_dims, keepdim=True)
 

--- a/FrEIA/modules/all_in_one_block.py
+++ b/FrEIA/modules/all_in_one_block.py
@@ -239,6 +239,9 @@ class AllInOneBlock(InvertibleModule):
 
     def forward(self, x, c=[], rev=False, jac=True):
         '''See base class docstring'''
+        if x.shape[1:] != self.dims_in[0][1:]:
+            raise RuntimeError(f"Expected input of shape {self.dims_in[0]}, "
+                             f"got {x.shape}.")
         if self.householder:
             self.w_perm = self._construct_householder_permutation()
             if rev or self.reverse_pre_permute:

--- a/FrEIA/modules/all_in_one_block.py
+++ b/FrEIA/modules/all_in_one_block.py
@@ -239,9 +239,9 @@ class AllInOneBlock(InvertibleModule):
 
     def forward(self, x, c=[], rev=False, jac=True):
         '''See base class docstring'''
-        if x[0].shape[1:] != self.dims_in[0][1:]:
+        if tuple(x[0].shape[1:]) != self.dims_in[0]:
             raise RuntimeError(f"Expected input of shape {self.dims_in[0]}, "
-                             f"got {x.shape}.")
+                             f"got {tuple(x[0].shape[1:])}.")
         if self.householder:
             self.w_perm = self._construct_householder_permutation()
             if rev or self.reverse_pre_permute:

--- a/FrEIA/modules/all_in_one_block.py
+++ b/FrEIA/modules/all_in_one_block.py
@@ -155,11 +155,11 @@ class AllInOneBlock(InvertibleModule):
             self.vk_householder = nn.Parameter(0.2 * torch.randn(self.householder, channels), requires_grad=True)
             self.w_perm = None
             self.w_perm_inv = None
-            self.w_0 = nn.Parameter(torch.from_numpy(w), requires_grad=False)
+            self.w_0 = nn.Parameter(torch.from_numpy(w).float(), requires_grad=False)
         elif permute_soft:
-            self.w_perm = nn.Parameter(torch.from_numpy(w).view(channels, channels, *([1] * self.input_rank)).contiguous(),
+            self.w_perm = nn.Parameter(torch.from_numpy(w).float().view(channels, channels, *([1] * self.input_rank)).contiguous(),
                                        requires_grad=False)
-            self.w_perm_inv = nn.Parameter(torch.from_numpy(w.T).view(channels, channels, *([1] * self.input_rank)).contiguous(),
+            self.w_perm_inv = nn.Parameter(torch.from_numpy(w.T).float().view(channels, channels, *([1] * self.input_rank)).contiguous(),
                                            requires_grad=False)
         else:
             self.w_perm = nn.Parameter(w_index, requires_grad=False)

--- a/FrEIA/modules/all_in_one_block.py
+++ b/FrEIA/modules/all_in_one_block.py
@@ -102,10 +102,13 @@ class AllInOneBlock(InvertibleModule):
         self.splits = [split_len1, split_len2]
 
         try:
-            self.permute_function = {0: F.linear,
-                                     1: F.conv1d,
-                                     2: F.conv2d,
-                                     3: F.conv3d}[self.input_rank]
+            if permute_soft or learned_householder_permutation:
+                self.permute_function = {0: F.linear,
+                                        1: F.conv1d,
+                                        2: F.conv2d,
+                                        3: F.conv3d}[self.input_rank]
+            else:
+                self.permute_function = lambda x, p: x[:, p]
         except KeyError:
             raise ValueError(f"Data is {1 + self.input_rank}D. Must be 1D-4D.")
 
@@ -143,6 +146,7 @@ class AllInOneBlock(InvertibleModule):
         if permute_soft:
             w = special_ortho_group.rvs(channels)
         else:
+            w_index = torch.randperm(channels, requires_grad=False)
             w = np.zeros((channels, channels))
             for i, j in enumerate(np.random.permutation(channels)):
                 w[i, j] = 1.
@@ -155,11 +159,14 @@ class AllInOneBlock(InvertibleModule):
             self.w_perm = None
             self.w_perm_inv = None
             self.w_0 = nn.Parameter(torch.FloatTensor(w), requires_grad=False)
-        else:
+        elif permute_soft:
             self.w_perm = nn.Parameter(torch.FloatTensor(w).view(channels, channels, *([1] * self.input_rank)),
                                        requires_grad=False)
             self.w_perm_inv = nn.Parameter(torch.FloatTensor(w.T).view(channels, channels, *([1] * self.input_rank)),
                                            requires_grad=False)
+        else:
+            self.w_perm = nn.Parameter(w_index, requires_grad=False)
+            self.w_perm_inv = nn.Parameter(torch.argsort(w_index), requires_grad=False)
 
         if subnet_constructor is None:
             raise ValueError("Please supply a callable subnet_constructor "

--- a/FrEIA/modules/invertible_resnet.py
+++ b/FrEIA/modules/invertible_resnet.py
@@ -30,9 +30,8 @@ class ActNorm(InvertibleModule):
 
         self.register_buffer("is_initialized", torch.tensor(False))
 
-        dim = next(iter(dims_in))[0]
-        self.log_scale = nn.Parameter(torch.empty(1, dim))
-        self.loc = nn.Parameter(torch.empty(1, dim))
+        self.log_scale = nn.Parameter(torch.empty(1, *dims_in))
+        self.loc = nn.Parameter(torch.empty(1, *dims_in))
 
         if init_data is not None:
             self.initialize(init_data)

--- a/FrEIA/modules/splines/binned.py
+++ b/FrEIA/modules/splines/binned.py
@@ -75,7 +75,8 @@ class BinnedSplineBase(InvertibleModule):
             default_domain: tuple of (left, right, bottom, top) default spline domain values
                 these values will be used as the starting domain (when the network outputs zero)
             identity_tails: whether to use identity tails for the spline
-            domain_clamping: clamping value for the domain
+            domain_clamping: clamping value for the domain, if float,
+                clamp spline width and height to (-domain_clamping, domain_clamping)
         """
         if dims_c is None:
             dims_c = []

--- a/FrEIA/modules/splines/rational_quadratic.py
+++ b/FrEIA/modules/splines/rational_quadratic.py
@@ -164,7 +164,8 @@ def rational_quadratic_spline(x: torch.Tensor,
 
         # Eq 29 in the appendix of the paper
         discriminant = b ** 2 - 4 * a * c
-        assert torch.all(discriminant >= 0), f"Discriminant must be positive, but is violated by {torch.min(discriminant)}"
+        if not torch.all(discriminant >= 0):
+            raise(RuntimeError(f"Discriminant must be positive, but is violated by {torch.min(discriminant)}"))
 
         xi = 2 * c / (-b - torch.sqrt(discriminant))
 

--- a/FrEIA/modules/splines/rational_quadratic.py
+++ b/FrEIA/modules/splines/rational_quadratic.py
@@ -164,7 +164,7 @@ def rational_quadratic_spline(x: torch.Tensor,
 
         # Eq 29 in the appendix of the paper
         discriminant = b ** 2 - 4 * a * c
-        assert torch.all(discriminant >= 0)
+        assert torch.all(discriminant >= 0), f"Discriminant must be positive, but is violated by {torch.min(discriminant)}"
 
         xi = 2 * c / (-b - torch.sqrt(discriminant))
 


### PR DESCRIPTION
These changes include a few stability improvements and minor bugfixes to FrEIA modules:
- The hard permutation in the AllInOne coupling block implementation was changed from a permutation matrix multiplication (ch x ch parameters) to an indexing tensor (ch parameters), which significantly reduces model size especially after flattening high dimensional data
- softclamping in the AllInOne block now no longer scales the near-linear part by the clamping boundaries (clamp * tanh(x) -> clamp * tanh(x/clamp))
- added a new parameter "domain_clamping" to BinnedSplineBase, which softclamps the domain width and height of the spline to (-domain_clamping, domain_clamping), since total width/height > 0 is always true before clamping, effectively this restricts the splines to a domain of (0, domain_clamping).
- In rational quadratic splines, if the discriminant check fails, added the violating value to the error message to differentiate between numerical errors (negative discriminant close to 0) and training instabilities (NaN values).
- fixed a bug in ActNorm that prevented loading of >1D ActNorm layers. The actnorm scale and mean are now initialized to be full-dimensional, not just on the channel dimension (which only was the case after the values were set on the first batch).