### PR TITLE
Adjusted ActNorm to work as described in the paper

### DIFF
--- a/tests/test_invertible_resnet.py
+++ b/tests/test_invertible_resnet.py
@@ -36,8 +36,12 @@ class ActNormTest(unittest.TestCase):
         self.assertStandardMoments(y_)
 
     def assertStandardMoments(self, data):
-        self.assertTrue(torch.allclose(torch.mean(data, dim=0), torch.zeros(data.shape[-1]), atol=1e-7))
-        self.assertTrue(torch.allclose(torch.std(data, dim=0), torch.ones(data.shape[-1])))
+        dims = [0] + list(range(2, data.ndim))
+        mean = torch.mean(data, dim=dims)
+        std = torch.std(data, dim=dims)
+
+        self.assertTrue(torch.allclose(mean, torch.zeros_like(mean), atol=1e-7))
+        self.assertTrue(torch.allclose(std,  torch.ones_like(std)))
 
 
 class IResNetTest(unittest.TestCase):


### PR DESCRIPTION
This PR involves:

- Initializing the ActNorm Parameters to unit size in all dimensions except the channel dimension
- Drawing the mean and std over the batch dimension, as well as any dimensions beyond the channel dimension
- Checking the batch for correct shape before overwriting the parameters
- Adjusting the tests to reflect these changes

For free with these changes comes:
- A fix for silent device moves in the initialization method
- An additional check for an initialization batch that has zero standard deviation in any channel