### PR TITLE
Bug fix InvertibleSigmoid

### DIFF
--- a/FrEIA/modules/fixed_transforms.py
+++ b/FrEIA/modules/fixed_transforms.py
@@ -175,8 +175,10 @@ class InvertibleSigmoid(InvertibleModule):
         # the following is the diagonal Jacobian as sigmoid is an element-wise op
         logJ = torch.log(1 / ((1 + torch.exp(_input)) * (1 + torch.exp(-_input))))
         # determinant of a log diagonal Jacobian is simply the sum of its diagonals
-        detLogJ = logJ.sum(1)
+        detLogJ = sum_except_batch(logJ)
+        
         if not rev:
             return ((result, ), detLogJ)
         else:
             return ((result, ), -detLogJ)
+            


### PR DESCRIPTION
Change computation of log jac det in InvertibleSigmoid to enable arbitrary input dimensions.